### PR TITLE
Added file dialog for read function (#9)

### DIFF
--- a/commands/fitsio.py
+++ b/commands/fitsio.py
@@ -13,7 +13,7 @@ def read(directory):
         try:
             paths = glob.glob("{}/*.fits*".format(tkinter.filedialog.askdirectory()))
         except:
-            print("Visual file dialog does not exist, please specify path to directory to save fitsfiles.")
+            click.echo("Visual file dialog does not exist, please use option -d and specify path to directory to read fitsfiles.", err=True)
             quit()
     else:
         paths = glob.glob("{}/*.fits*".format(directory))

--- a/commands/fitsio.py
+++ b/commands/fitsio.py
@@ -11,10 +11,11 @@ def read(directory):
     # add try (evaluate if the try is efficient)
     if directory == None:
         try:
-            paths = glob.glob("{}/*.fits*".format(tkinter.filedialog.askdirectory()))
+            directory = tkinter.filedialog.askdirectory()
         except:
             click.echo("Visual file dialog does not exist, please use option -d and specify path to directory to read fitsfiles.", err=True)
             quit()
+        paths = glob.glob("{}/*.fits*".format(directory))
     else:
         paths = glob.glob("{}/*.fits*".format(directory))
     hduls = [fits.open(p) for p in paths]

--- a/commands/fitsio.py
+++ b/commands/fitsio.py
@@ -4,10 +4,13 @@ from astropy.io import fits
 import glob
 
 @sdi.cli.command("read")
-@click.option('-d', '--directory', type=str, help="Specify path to directory of fitsfiles.", required=True)
+@click.option('-d', '--directory', type=str, help="Specify path to directory of fitsfiles.", required=False)
 @sdi.generator
 def read(directory):
-    paths = glob.glob("{}/*.fits*".format(directory))
+    if directory == None:
+        paths = tkinter.filedialog.askopenfilenames()
+    else:
+        paths = glob.glob("{}/*.fits*".format(directory))
     hduls = [fits.open(p) for p in paths]
     return hduls
 

--- a/commands/fitsio.py
+++ b/commands/fitsio.py
@@ -2,13 +2,14 @@ import click
 import sdi
 from astropy.io import fits
 import glob
+import tkinter
 
 @sdi.cli.command("read")
 @click.option('-d', '--directory', type=str, help="Specify path to directory of fitsfiles.", required=False)
 @sdi.generator
 def read(directory):
     if directory == None:
-        paths = tkinter.filedialog.askopenfilenames()
+        paths = glob.glob("{}/*.fits*".format(tkinter.filedialog.askdirectory()))
     else:
         paths = glob.glob("{}/*.fits*".format(directory))
     hduls = [fits.open(p) for p in paths]

--- a/commands/fitsio.py
+++ b/commands/fitsio.py
@@ -2,7 +2,7 @@ import click
 import sdi
 from astropy.io import fits
 import glob
-import tkinter
+from tkinter.filedialog import askdirectory
 
 @sdi.cli.command("read")
 @click.option('-d', '--directory', type=str, help="Specify path to directory of fitsfiles.", required=False)
@@ -11,7 +11,7 @@ def read(directory):
     # add try (evaluate if the try is efficient)
     if directory == None:
         try:
-            directory = tkinter.filedialog.askdirectory()
+            directory = askdirectory()
         except:
             click.echo("Visual file dialog does not exist, please use option -d and specify path to directory to read fitsfiles.", err=True)
             quit()

--- a/commands/fitsio.py
+++ b/commands/fitsio.py
@@ -8,8 +8,13 @@ import tkinter
 @click.option('-d', '--directory', type=str, help="Specify path to directory of fitsfiles.", required=False)
 @sdi.generator
 def read(directory):
+    # add try (evaluate if the try is efficient)
     if directory == None:
-        paths = glob.glob("{}/*.fits*".format(tkinter.filedialog.askdirectory()))
+        try:
+            paths = glob.glob("{}/*.fits*".format(tkinter.filedialog.askdirectory()))
+        except:
+            print("Visual file dialog does not exist, please specify path to directory to save fitsfiles.")
+            quit()
     else:
         paths = glob.glob("{}/*.fits*".format(directory))
     hduls = [fits.open(p) for p in paths]

--- a/commands/fitsio.py
+++ b/commands/fitsio.py
@@ -15,9 +15,7 @@ def read(directory):
         except:
             click.echo("Visual file dialog does not exist, please use option -d and specify path to directory to read fitsfiles.", err=True)
             quit()
-        paths = glob.glob("{}/*.fits*".format(directory))
-    else:
-        paths = glob.glob("{}/*.fits*".format(directory))
+    paths = glob.glob("{}/*.fits*".format(directory))
     hduls = [fits.open(p) for p in paths]
     return hduls
 

--- a/commands/snr_function.py
+++ b/commands/snr_function.py
@@ -23,7 +23,7 @@ def snr(hduls, name="SCI"):
 		data = hdul[name].data
 
 		# identify background rms
-		boxsize=(shape)
+		boxsize=(data.shape)
 		bkg = Background2D(data, boxsize)
 		bkg_mean_rms = np.mean(bkg.background_rms)
 
@@ -45,7 +45,6 @@ def snr(hduls, name="SCI"):
 		noise = bkg_mean_rms
 		SNR = (signal)/(noise)
 		hdul["CAT"].header.append(('SNR',SNR,"signal to noise ratio" ))
-
 
 	return (hdul for hdul in hduls)
 


### PR DESCRIPTION
This pull request adds a new way to specify a directory to `sdi read`. Now, if
no directory is given with the `-d` option, a tkinter file dialog is opened to
prompt the user to choose a directory.

If tkinter is not available (e.g. over an ssh session), the user is reminded
to specify a directory with `-d`.

Acceptance criteria:
[ ] opens a file dialog if `-d` is not given
[ ] correctly reads all fits files in the chosen directory
[ ] reminds te user to use `-d` if tkinter is unavailable.

- Added new feature for read function (issue #9)
- Update fitsio.py
- Update fitsio.py
- Update fitsio.py
- Update fitsio.py
- Modified if/else in Edgar's PR
- Filedialog is a submodule, not an attribute
